### PR TITLE
install virtctl into each kubevirt unit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     needs: 
       - call-inclusive-naming-check
     with:
-      python: "['3.9', '3.10', '3.11']"
+      python: "['3.8', '3.9', '3.10', '3.11']"
 
   integration-tests:
     name: Integration test with VMWare

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,9 @@ jobs:
     timeout-minutes: 360
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Setup operator environment

--- a/README.md
+++ b/README.md
@@ -41,20 +41,20 @@ for developer guidance.
 Deploying the charm into an existing juju machine model with `charmed-kubernetes` is as simple as 
 
 ```bash
-$ juju deploy kubevirt --channel <channel> --config operator-release='<v0.min.bug>' --trust
+juju deploy kubevirt --channel <channel> --config operator-release='<v0.min.bug>' --trust
 ```
 
 Next, the charm will need to be related to every `kubernetes-worker` in the model. If you have multiple
 kubernetes-worker applications, you may relate the same charm to those multiple applications.
 
 ```bash
-$ juju relate kubernetes-worker kubevirt:juju-info
+juju relate kubernetes-worker kubevirt:juju-info
 ```
 
 Lastly, the charm will need to relate to the control-plane charm in the model.  
 
 ```bash
-$ juju relate kubernetes-control-plane kubevirt:kube-control
+juju relate kubernetes-control-plane kubevirt:kube-control
 ```
 
 This will install a subordinate unit on every worker, use its cluster credentials to
@@ -135,5 +135,5 @@ or install a `virtctl` plugin into `kubectl`.  See [upstream docs](https://kubev
 for more details on using `virtctl`.  For ease of use this charm can expose `virtctl` through `juju run`
 
 ```bash
-$ juju run --unit kubevirt/leader -- ./virtctl help
+juju run --unit kubevirt/leader -- ./virtctl help
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ More information: https://charmhub.io/kubevirt
 
 As an optional addon to charmed-kubernetes, this charm allows for installation of a selectable version of kubevirt into a cluster. KubeVirt allows for virtual machine instances to be launched as kubernetes workloads which interact with other internal services within a kubernetes cluster.
 
-### Details
+### Basics
 
 * Requires a `charmed-kubernetes` deployment launched by juju
 * Deploy the `kubevirt` charm in the model relating to the control-plane and to the worker
@@ -34,3 +34,106 @@ Please see the [Juju SDK docs](https://juju.is/docs/sdk) for guidelines
 on enhancements to this charm following best practice guidelines, and
 [CONTRIBUTING.md](https://github.com/charmed-kubernetes/charm-azure-cloud-provider/blob/main/CONTRIBUTING.md)
 for developer guidance.
+
+
+## Installation
+
+Deploying the charm into an existing juju machine model with `charmed-kubernetes` is as simple as 
+
+```bash
+$ juju deploy kubevirt --channel <channel> --config operator-release='<v0.min.bug>' --trust
+```
+
+Next, the charm will need to be related to every `kubernetes-worker` in the model. If you have multiple
+kubernetes-worker applications, you may relate the same charm to those multiple applications.
+
+```bash
+$ juju relate kubernetes-worker kubevirt:juju-info
+```
+
+Lastly, the charm will need to relate to the control-plane charm in the model.  
+
+```bash
+$ juju relate kubernetes-control-plane kubevirt:kube-control
+```
+
+This will install a subordinate unit on every worker, use its cluster credentials to
+install the KubeVirt manifests into the cluster, and detect if the related workers 
+all have access to an internal `/dev/kvm` device.  The necessary binaries will be installed
+on the worker machines using apt (fundamentally `qemu-system-*` or `qemu`) and apparmor
+adjustments will be made after the installation. 
+
+### Networking
+
+Within this repository, we will be testing with the default charmed-kubernetes CNI (calico) and will
+not be testing with multiple network interfaces per VM instance.  With a stock CNI, your VM will
+have access to a single network interface -- the same that is used to communicate with the rest 
+of the cluster. Fortunately, not much precludes KubeVirt from accessing other network interfaces
+through more advanced CNIs.
+
+See [Usage](#NetworkingUsage) for more details
+
+### Storage
+
+Within this repository, we will be testing with a VMWare cluster which can provider storage through 
+the `vsphere-cloud-provider` charm.  This charm can allocate block storage in the VMWare cluster,
+mount the block storage into the VM, and use it for persistent storage through a PVC. The very 
+same methodology may be used within other clouds with storage classes and PVCs.
+
+
+## Usage
+
+Once installed, follow [upstream documenation](https://kubevirt.io/) for complete usage guides.
+
+What to expect:
+
+* a `kubevirt` namespace will be created which contains
+  * the replicaset resources: `virt-api`, `virt-controller`, and `virt-operator`
+  * the daemonset resource: `virt-handler`
+  * the KubeVirt resource: `kubevirt`
+
+
+Any configuration changes to the `KubeVirt` resource should be considered properies of this charm
+though not all have yet been implemented.
+
+* `image-registry`: per upstream, the kubevirt images are hosted on `quay.io`
+* `software-emulation`: the charm will detect if all the workers have access to `/dev/kvm`.
+  * If true, then `configuration.developerConfiguration.useEmulation` will be `false`
+  * If one machine doesn't have `/dev/kvm`, then the charm is forced to enable `useEmulation`
+* `pvc-tolerate-less-space-up-to-percent`: is an adjustment necessary under certain circumstances
+   where the cloud provider's storage isn't quite sized to create filesystems with enough available space
+   see [upstream docs](https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#persistentvolumeclaim) for
+   more guidance.
+
+### ContainerDisk Images
+ContainerDisks are a specialized volume type for Virtual Machine instances.  They consist of a file (`qcow2` or `raw`) in the
+`/disk` directory with permissions `o107`.  
+
+See [upstream docs](https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#containerdisk) to create your own disk images.
+
+### Networking [NetworkingUsage]
+
+Virtual Machines will have one `pod` interfaces, and can add multiple `multus` network interfaces provided via multus.
+
+Multus can be installed into a kubernetes cluster with the [multus](https://charmhub.io/multus) charm
+
+See the [upstream docs](https://kubevirt.io/user-guide/virtual_machines/interfaces_and_networks/) to determine the
+VMI configuration for multiple nics.
+
+### Storage
+
+Virtual Machine instances may be booted with multiple disk devices, each of which can be defined by various kubernetes 
+storage components.  See [Supported Volume Types](https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#volumes)
+for a complete list of volume types.
+
+
+### VM Management
+
+Creating and Destroying the VM instances is handled through the kubernetes api using `kubectl` commands, but some VM management
+takes place using the `virt-api` service in the kubernetes cluster. One may use the `virtctl` client directly
+or install a `virtctl` plugin into `kubectl`.  See [upstream docs](https://kubevirt.io/user-guide/operations/virtctl_client_tool/)
+for more details on using `virtctl`.  For ease of use this charm can expose `virtctl` through `juju run`
+
+```bash
+$ juju run --unit kubevirt/leader -- ./virtctl help
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ops >= 1.5.0
 lightkube>=0.10.1,<1.0.
 pydantic
-git+https://github.com/canonical/ops-lib-manifest.git@c5d6a00084954af7578dd0f456491f4ee60e0311
+git+https://github.com/canonical/ops-lib-manifest.git@971cc75c36b7dbbcc75793cc9146465f76514b2e
 git+https://github.com/charmed-kubernetes/interface-kube-control.git@6dd289d1c795fdeda1bed17873b8d6562227c829#subdirectory=ops

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ops >= 1.5.0
 lightkube>=0.10.1,<1.0.
 pydantic
-git+https://github.com/canonical/ops-lib-manifest.git@332444d77c6bacbb09f5d46d68d4b6db8fada176
+git+https://github.com/canonical/ops-lib-manifest.git@818721dbcd1b6806fff78be3b20952e6eee7f210
 git+https://github.com/charmed-kubernetes/interface-kube-control.git@6dd289d1c795fdeda1bed17873b8d6562227c829#subdirectory=ops

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ops >= 1.5.0
 lightkube>=0.10.1,<1.0.
 pydantic
-git+https://github.com/canonical/ops-lib-manifest.git@971cc75c36b7dbbcc75793cc9146465f76514b2e
+git+https://github.com/canonical/ops-lib-manifest.git@a02d83af8febeed39b7324b0247368cfc7105d73
 git+https://github.com/charmed-kubernetes/interface-kube-control.git@6dd289d1c795fdeda1bed17873b8d6562227c829#subdirectory=ops

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ops >= 1.5.0
 lightkube>=0.10.1,<1.0.
 pydantic
-git+https://github.com/canonical/ops-lib-manifest.git@818721dbcd1b6806fff78be3b20952e6eee7f210
+git+https://github.com/canonical/ops-lib-manifest.git@c5d6a00084954af7578dd0f456491f4ee60e0311
 git+https://github.com/charmed-kubernetes/interface-kube-control.git@6dd289d1c795fdeda1bed17873b8d6562227c829#subdirectory=ops

--- a/src/charm.py
+++ b/src/charm.py
@@ -152,13 +152,9 @@ class CharmKubeVirtCharm(CharmBase):
             self.unit.status = WaitingStatus(", ".join(unready))
             return
 
-        phases = ", ".join(
-            f"{name}: {phase}"
-            for name, manifest in self.collector.manifests.items()
-            for phase in manifest.phases()
-        )
+        phases = ", ".join(f"{obj}: {phase}" for obj, phase in self.kube_operator.phases)
 
-        status_type = ActiveStatus if "Deployed" in phases else WaitingStatus
+        status_type = WaitingStatus if "Deployed" not in phases else ActiveStatus
         self.unit.status = status_type(phases)
         if self.unit.is_leader():
             self.unit.set_workload_version(self.collector.short_version)

--- a/src/charm.py
+++ b/src/charm.py
@@ -146,7 +146,11 @@ class CharmKubeVirtCharm(CharmBase):
 
             return f"{rsc} is not {cond.type}"
 
-        unready = list(filter(unready_conditions, self.collector.conditions.items()))
+        unready = [
+            cond
+            for pair in self.collector.conditions.items()
+            if (cond := unready_conditions(pair))
+        ]
 
         if unready:
             self.unit.status = WaitingStatus(", ".join(unready))

--- a/src/charm.py
+++ b/src/charm.py
@@ -32,7 +32,7 @@ VIRTCTL_URL = "https://github.com/kubevirt/kubevirt/releases/download/{version}/
 @contextmanager
 def _modified_env(**update: str):
     orig = dict(os.environ)
-    os.environ.update(update)
+    os.environ.update({k: v for k, v in update.items() if isinstance(v, str)})
     try:
         yield
     finally:
@@ -42,9 +42,8 @@ def _modified_env(**update: str):
 
 def _fetch_file(url, dest):
     proxies = {
-        "https_proxy": os.environ.get("JUJU_CHARM_HTTPS_PROXY"),
-        "http_proxy": os.environ.get("JUJU_CHARM_HTTP_PROXY"),
-        "no_proxy": os.environ.get("JUJU_CHARM_NO_PROXY"),
+        "HTTPS_PROXY": os.environ.get("JUJU_CHARM_HTTPS_PROXY"),
+        "HTTP_PROXY": os.environ.get("JUJU_CHARM_HTTP_PROXY"),
     }
     with _modified_env(**proxies):
         proxy = urllib.request.ProxyHandler()

--- a/src/kubevirt_manifests.py
+++ b/src/kubevirt_manifests.py
@@ -90,11 +90,12 @@ class KubeVirtOperator(Manifests):
 
         return None
 
+    @property
     def phases(self):
         """Details phases of resources in this manifest."""
         return sorted(
-            phase
+            (obj, phase)
             for obj in self.installed_resources()
             if obj.kind == "KubeVirt"
-            for phase in [obj.resource.status["phase"]]
+            for phase in [obj.resource.status["phase"] if obj.resource.status else "Unknown"]
         )

--- a/tests/data/vmi-ubuntu.yaml
+++ b/tests/data/vmi-ubuntu.yaml
@@ -19,6 +19,12 @@ spec:
       - name: cloudinitdisk
         disk:
           bus: virtio
+      interfaces:
+      - name: default
+        bridge: {}
+  networks:
+  - name: default
+    pod: {}
   volumes:
   - name: containerdisk
     containerDisk:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,6 +4,8 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 
+import unittest.mock as mock
+
 import ops.testing
 import pytest
 
@@ -21,5 +23,29 @@ def harness():
         harness.cleanup()
 
 
-def test_passes():
-    pass
+@pytest.fixture
+def harness_installed(harness):
+    harness.set_leader(True)
+    with mock.patch("charm.CharmKubeVirtCharm._install_or_upgrade", autospec=True):
+        harness.begin_with_initial_hooks()
+        yield harness
+
+
+def test_update_status_with_conditions(harness_installed):
+    harness_installed.charm.stored.deployed = True
+    harness_installed.charm.stored.installed = True
+
+    mock_installed = list(harness_installed.charm.kube_operator.status())
+    mock_installed[0].resource.kind = "KubeVirt"
+    mock_installed[0].resource.metadata.namespace = "kubevirt"
+    mock_installed[0].resource.metadata.name = "kubevirt"
+    mock_installed[0].resource.status.conditions = [mock.MagicMock(type="Tested", status="False")]
+
+    with mock.patch(
+        "ops.manifests.manifest.Manifests.installed_resources",
+    ) as mocker:
+        mocker.return_value = mock_installed
+        assert harness_installed.charm._update_status({}) is None
+    assert (
+        harness_installed.charm.unit.status.message == "KubeVirt/kubevirt/kubevirt is not Tested"
+    )


### PR DESCRIPTION
* Adding usage documentation
* Handle retry and blocking logic into common methods
* charm-upgrade re-installs binaries
* refactor of `install_and_upgrade` method to allow ending in error states

* depends on https://github.com/canonical/ops-lib-manifest/pull/15