### PR TITLE
Fix unrecoverable installation failure with charm action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -45,3 +45,5 @@ sync-resources:
         Space separated list of kubernetes resource types
         to use a filter during the sync. This helps limit
         which missing resources are applied.
+sync-install:
+  description: Reinstall binaries and their configuration

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -114,6 +114,7 @@ async def test_launch_vmi(kubernetes):
         lambda ops, dep: (
             dep.metadata.name == vmi.metadata.name and dep.status["phase"] == "Running"
         ),
+        delay=5 * 60,
     )
 
     instance = await kubernetes.get(type(vmi), vmi.metadata.name)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from async_timeout import timeout
 from lightkube.codecs import from_dict
 from lightkube.generic_resource import get_generic_resource
 from pytest_operator.plugin import OpsTest
@@ -71,10 +72,11 @@ async def test_kubevirt_deployed(kubernetes):
     assert kubevirt.status["phase"] == "Deployed"
 
 
-async def wait_for(client, resource, match):
-    async for op, dep in client.watch(resource):
-        if match(op, dep):
-            return
+async def wait_for(client, resource, match, delay=15):
+    async with timeout(delay):
+        async for op, dep in client.watch(resource):
+            if match(op, dep):
+                return
 
 
 async def test_launch_vmi(kubernetes):

--- a/tox.ini
+++ b/tox.ini
@@ -80,6 +80,7 @@ deps =
     pytest
     juju
     pytest-operator
+    async-timeout
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native \


### PR DESCRIPTION
While debugging [LP#2012106](https://bugs.launchpad.net/charm-kubevirt/+bug/2012106) found the charm could get stuck with an installation failure that couldn't be recovered except through repetitive charm upgrades.

This provides a charm action to run when the installation issues are resolved